### PR TITLE
Add support for Sitecore 9 Dependency Injection in pipeline

### DIFF
--- a/Helpfulcore.Wildcards/App_Config/Include/Helpfulcore/Helpfulcore.Wildcards.config
+++ b/Helpfulcore.Wildcards/App_Config/Include/Helpfulcore/Helpfulcore.Wildcards.config
@@ -28,6 +28,7 @@
     <pipelines>
       <mvc.getPageItem>
         <processor type="Helpfulcore.Wildcards.Pipelines.Response.GetPageItem.GetFromWildcard, Helpfulcore.Wildcards"
+                   resolve="true"
                    patch:after="processor[@type='Sitecore.Mvc.Pipelines.Response.GetPageItem.GetFromOldContext, Sitecore.Mvc']" />
       </mvc.getPageItem>
     </pipelines>

--- a/Helpfulcore.Wildcards/Helpfulcore.Wildcards.csproj
+++ b/Helpfulcore.Wildcards/Helpfulcore.Wildcards.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Helpfulcore.Wildcards</RootNamespace>
     <AssemblyName>Helpfulcore.Wildcards</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Helpfulcore.Wildcards/Pipelines/Response/GetPageItem/GetFromWildcard.cs
+++ b/Helpfulcore.Wildcards/Pipelines/Response/GetPageItem/GetFromWildcard.cs
@@ -1,14 +1,16 @@
-﻿using System.Web;
-using Helpfulcore.Wildcards.ItemResolving;
+﻿using Helpfulcore.Wildcards.ItemResolving;
 using Sitecore;
+using Sitecore.Abstractions;
 using Sitecore.Data.Items;
-using Sitecore.Diagnostics;
 using Sitecore.Mvc.Pipelines.Response.GetPageItem;
+using System.Web;
 
 namespace Helpfulcore.Wildcards.Pipelines.Response.GetPageItem
 {
-	public class GetFromWildcard : GetPageItemProcessor
+    public class GetFromWildcard : GetPageItemProcessor
 	{
+        public GetFromWildcard(BaseClient baseClient) : base(baseClient) { }
+
         private const string OriginalItemCacheKey = "Wildcards.OriginalItem";
 
         public override void Process(GetPageItemArgs args)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# About this branch
+It was created to support of Sitecore 9.2+ pipeline with Dependency Injection (DI) and NET Framework v4.7.2.
+
 ### Helpfulcore - helpful features for Sitecore
 # Helpfulcore Wildcards
 Wildcard Module for Sitecore 7+ using Content Search API


### PR DESCRIPTION
This PR adds support for Sitecore 9+ pipeline

The difference is that `GetPageItemProcessor` is now uses Dependency Injection (DI) and requires `BaseClient`.

Probably it is good to create a separate branch for v9 and retarget this PR.